### PR TITLE
Dont initialize if there is no global menu

### DIFF
--- a/MenuPin/ClientResources/Scripts/MenuPin/MenuPinInit.js
+++ b/MenuPin/ClientResources/Scripts/MenuPin/MenuPinInit.js
@@ -43,11 +43,11 @@
                 this.inherited(arguments);
 
                 // The context changes after the UI has been loaded so we can be sure that registry contains the global meny container
-                _initHandle = topic.subscribe("/epi/shell/context/current", lang.hitch(this, "_onContextCurrent"));
+                this._initHandle = topic.subscribe("/epi/shell/context/current", lang.hitch(this, "_onContextCurrent"));
             },
 
             _onContextCurrent: function (ctx) {
-                -_initHandle.remove();
+                this._initHandle.remove();
                 this._init();
             },
 
@@ -56,6 +56,10 @@
                 this.menuPinButtons = query(".menuPinButton");
 
                 this.globalMenu = registry.byId("globalMenuContainer");
+
+                if (!this.globalMenu) {
+                    return;
+                }
 
                 topic.subscribe("/menupin/pinclicked", lang.hitch(this, "_pinClicked"));
                 topic.subscribe("/menupin/pinheld", lang.hitch(this, "_pinHeld"));


### PR DESCRIPTION
There is no point in initializing the plugin if there is no global menu
since there is nothing to pin.

This way we will avoid breaking views without the global menu, like the
dashboard, if someone publishes the "/epi/shell/context/current" topic.